### PR TITLE
removing null lat and lng values from map 

### DIFF
--- a/src/app/components/map/map.js
+++ b/src/app/components/map/map.js
@@ -80,9 +80,13 @@ export default class Map extends EventEmitter {
   getKey(record, column) {
     const split = column.split('.');
     if (split.length === 1) {
-      return record[split[0]];
-    }
+      let splitRecord = record[split[0]];
 
+      if (splitRecord === '') {
+        splitRecord = NaN;
+      }
+      return splitRecord;
+    }
     return this.getKey(record[split.shift()], split.join('.'));
   }
 

--- a/src/app/components/map/map.js
+++ b/src/app/components/map/map.js
@@ -80,12 +80,7 @@ export default class Map extends EventEmitter {
   getKey(record, column) {
     const split = column.split('.');
     if (split.length === 1) {
-      let splitRecord = record[split[0]];
-
-      if (splitRecord === '') {
-        splitRecord = NaN;
-      }
-      return splitRecord;
+      return record[split[0]];
     }
     return this.getKey(record[split.shift()], split.join('.'));
   }
@@ -107,7 +102,7 @@ export default class Map extends EventEmitter {
         true,
       ); // center on pacific ocean
 
-      if (Number.isNaN(lat) || Number.isNaN(lng)) return;
+      if (!Number.parseFloat(lat) || !Number.parseFloat(lng)) return;
 
       const marker = L.marker([lat, lng]);
 


### PR DESCRIPTION
Issue #97 
 
Lat and Lng values were being returned as strings, which function `Number.isNaN()` returns false