### PR TITLE
adding diagnostics module logic to create project

### DIFF
--- a/src/app/views/create-project/create-project.component.js
+++ b/src/app/views/create-project/create-project.component.js
@@ -432,6 +432,33 @@ class CreateProjectController {
     }
   }
 
+  diagnosticsChanged() {
+    if (!this.diagnostics) this.removeEntity('Diagnostics');
+    else {
+      let e;
+      if (this.existingConfig) {
+        e = this.existingConfig.config.entities.find(
+          entity => entity.conceptAlias === 'Diagnostics',
+        );
+      }
+      if (!e) {
+        e = {
+          conceptAlias: 'Diagnostics',
+      	  type: 'Diagnostics',
+          attributes: this.requiredAttributes.Diagnostics.map(a =>
+            Object.assign({}, a),
+          ),
+          rules: [],
+          worksheet: this.configLayout === 'single' ? 'Samples' : 'Diagnostics',
+          generateID: this.configLayout === 'single',
+          uniqueKey: 'diagnosticID',
+          conceptURI: 'http://rs.tdwg.org/dwc/terms/MeasurementOrFact',
+          parentEntity: 'Sample',
+        };
+      }
+      this.config.entities.push(e);
+    }
+  }
   samplePhotosChanged() {
     if (!this.samplePhotos) this.removeEntity('Sample_Photo');
     else {
@@ -475,6 +502,7 @@ class CreateProjectController {
     this.samplePhotos = false;
     this.nextgen = false;
     this.barcode = false;
+    this.diagnostics = false;
 
     this.config.entities.forEach(e => {
       switch (e.conceptAlias) {
@@ -494,6 +522,9 @@ class CreateProjectController {
           break;
         case 'fastqMetadata':
           this.nextgen = true;
+          break;
+        case 'diagnostics':
+          this.diagnostics = true;
           break;
         default:
       }

--- a/src/app/views/create-project/create-project.component.js
+++ b/src/app/views/create-project/create-project.component.js
@@ -228,7 +228,12 @@ class CreateProjectController {
           e.worksheet = 'Samples';
           e.generateID = true;
           e.generateEmptyTissue = false;
+        } else if (e.conceptAlias === 'Diagnostics') {
+          e.worksheet = 'Samples';
+          e.generateID = true;
+          e.generateEmptyTissue = false;
         }
+      }
       }
     });
   }
@@ -444,7 +449,7 @@ class CreateProjectController {
       if (!e) {
         e = {
           conceptAlias: 'Diagnostics',
-      	  type: 'Diagnostics',
+      	  type: 'DefaultEntity',
           attributes: this.requiredAttributes.Diagnostics.map(a =>
             Object.assign({}, a),
           ),

--- a/src/app/views/create-project/create-project.html
+++ b/src/app/views/create-project/create-project.html
@@ -370,6 +370,18 @@
                 Sample Photos</md-checkbox
               >
             </div>
+
+            <md-checkbox
+              ng-model="$ctrl.diagnostics"
+              class="md-align-top-left"
+              name="barcode"
+              ng-change="$ctrl.diagnosticsChanged()"
+            >
+              Diagnostics Module
+              <md-hints>
+                <md-hint>Diagnostics XXXXXXXXXXXXXXXXXXXXXXXX</md-hint>
+              </md-hints>
+            </md-checkbox>
           </md-step-body>
           <md-step-actions layout="row">
             <md-button class="md-primary md-raised" ng-click="$mdStep.$stepper.next()">


### PR DESCRIPTION
I added some code to handle a new diagnostics module under create project.
Also added diagnostics entity to the geome network.json file (under DEVELOP).  That posted fine.

When i run the code and create a project, the server responds with a 400 (bad request) error and:

"Could not find Entity implementation with type: "Diagnostics" in package: biocode.fims.config.models (through reference chain: biocode.fims.rest.services.subResources.ProjectsResource$NewProject["projectConfig"]->biocode.fims.config.project.ProjectConfig["entities"]->java.util.LinkedList[3])"

do we need to create a special Diagnostics type in fims-commons?  Or should i set the type to something else (see line 447 in views/create-project/create-project.component.js)

John