### PR TITLE
using $index for track by in query button lists

### DIFF
--- a/src/app/views/query/form/filter-buttons/filter-buttons.html
+++ b/src/app/views/query/form/filter-buttons/filter-buttons.html
@@ -64,7 +64,7 @@
               <md-option>-- Choose value --</md-option>
               <md-option
                 ng-value="list.value"
-                ng-repeat="list in $ctrl.getList($ctrl.conceptAlias, $chip.column) track by list.value"
+                ng-repeat="list in $ctrl.getList($ctrl.conceptAlias, $chip.column) track by $index"
               >
                 {{ list.value }}</md-option
               >


### PR DESCRIPTION
If list has duplicate value, query filters currently throw error. this fix allows duplicate values to be displayed. 