### PR TITLE
adds minZoom to mapTiles

### DIFF
--- a/src/app/components/map/map.js
+++ b/src/app/components/map/map.js
@@ -53,6 +53,7 @@ export default class Map extends EventEmitter {
 
     // fill screen with map, roughly 360 degrees of longitude
     const z = this.map.getBoundsZoom([[90, -180], [-90, 180]], true);
+
     this.map.setZoom(z);
 
     this.mapTiles = L.tileLayer(
@@ -61,6 +62,7 @@ export default class Map extends EventEmitter {
         id: 'mapbox/outdoors-v11',
         tileSize: 512,
         zoomOffset: -1,
+        minZoom: 1,
         access_token: mapboxToken,
       },
     );
@@ -74,6 +76,7 @@ export default class Map extends EventEmitter {
         id: 'mapbox/satellite-v9',
         tileSize: 512,
         zoomOffset: -1,
+        minZoom: 1,
         access_token: mapboxToken,
       },
     );
@@ -84,6 +87,7 @@ export default class Map extends EventEmitter {
         attribution:
           'Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri',
         maxZoom: 10,
+        minZoom: 1,
       },
     );
 


### PR DESCRIPTION
When we migrated to mapbox modern static tiles API, I implemented the changes suggested by mapbox: 
https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/



![Screen Shot 2020-04-24 at 7 58 31 AM](https://user-images.githubusercontent.com/35155534/80176477-66711e00-8601-11ea-9165-258ca556d4ef.png)

Due to the size change of the map tile, we needed to add zoom offset to keep the markets etc looking normal, but this caused an error in rendering zoom level 0 because when adjusting for zoom offset the API call was requesting a zoom level -1. I have added minZoom level of 1 to account for this to both mapBox tiles (outdoors and sattelite). 
I also added min zoom of 1 to the Esri ocean basemap tile just to keep the look consistent. 