### PR TITLE
fixes issue with catching undefined projects in the project service o…

### DIFF
--- a/src/app/services/project.service.js
+++ b/src/app/services/project.service.js
@@ -76,9 +76,11 @@ class ProjectService extends EventEmitter {
         if (!project) {
           return this.stats(true)
             .then(({ data }) => data.find(p => p.projectId === projectId))
-            .then(discoverableProject =>
-              Object.assign(discoverableProject, { limitedAccess: true }),
-            );
+            .then(discoverableProject => {
+              if (discoverableProject) {
+                Object.assign(discoverableProject, { limitedAccess: true });
+              }
+            });
         }
 
         return this.getConfig(project.projectId)


### PR DESCRIPTION
…n site load without project selected

When I made recent changes to check for discoverable projects in the project.service, I didn't include a check for undefined/non-selected projects in the code. This fixes that. 