### PR TITLE
discoverable bug

### DIFF
--- a/src/app/services/project.service.js
+++ b/src/app/services/project.service.js
@@ -76,11 +76,10 @@ class ProjectService extends EventEmitter {
         if (!project) {
           return this.stats(true)
             .then(({ data }) => data.find(p => p.projectId === projectId))
-            .then(discoverableProject => {
-              if (discoverableProject) {
-                Object.assign(discoverableProject, { limitedAccess: true });
-              }
-            });
+            .then(discoverableProject =>
+              Object.assign(discoverableProject, { limitedAccess: true }),
+            )
+            .catch(() => {});
         }
 
         return this.getConfig(project.projectId)


### PR DESCRIPTION
Needed to use catch rather than if statement in the get project promise in project.service.js. fixes the issue with viewing discoverable projects. issue #499 