### PR TITLE
adds check for selected project before adding projectID to gtag object

### DIFF
--- a/src/app/app.component.js
+++ b/src/app/app.component.js
@@ -34,7 +34,7 @@ class AppCtrl {
     this.ProjectService.on(PROJECT_CHANGED_EVENT, (p, ignoreReload) => {
       this.currentProject = p;
       this.setUserIsMember();
-      setProject(p ? p.projectId : undefined);
+      if (p) setProject(p.projectId);
       if (
         !ignoreReload &&
         !this.preventReload &&


### PR DESCRIPTION
this takes care of the "gtag is not defined" console error that appears every time geome loads without project selected